### PR TITLE
Changed atomic operations on flags

### DIFF
--- a/src/atomicvar.h
+++ b/src/atomicvar.h
@@ -33,7 +33,7 @@
  * and also it has a full barrier (__sync_lock_test_and_set has acquire barrier).
  * 
  * NOTE2: Unlike other atomic type, which aren't guaranteed to be lock free, c11 atmoic_flag does.
- * To check wether a type is lock free, atomic_is_lock_free() can be used. 
+ * To check whether a type is lock free, atomic_is_lock_free() can be used. 
  * It can be considered to limit the flag type to atomic_flag to improve performance.
  * 
  * Never use return value from the macros, instead use the AtomicGetIncr()

--- a/src/atomicvar.h
+++ b/src/atomicvar.h
@@ -12,14 +12,30 @@
  * atomicGetWithSync(var,value)  -- 'atomicGet' with inter-thread synchronization
  * atomicSetWithSync(var,value)  -- 'atomicSet' with inter-thread synchronization
  * 
- * The following macros should be used to use atomic operations on flags:
- * redisAtomicFlag - atomic flag type
- * REDIS_ATOMIC_FLAG_INIT - The atomic flag should be only initialized using this macro.
- * initialization example:
- * redisAtomicFlag my_atomic_flag = REDIS_ATOMIC_FLAG_INIT;
- * atomicFlagTestSet(var,testres_var) -- Set on the flag and put the previous state in testres_var
- * atomicFlagClear(var) -- Turn off the flag
- *
+ * Atomic operations on flags. 
+ * Flag type can be int, long, long long or their unsigned counterparts.
+ * The value of the flag can be 1 or 0.
+ * 
+ * atomicFlagGetSet(var,oldvalue_var) -- Get and set the atomic counter value
+ * 
+ * NOTE1: __atomic* and _Atomic implementations can be actually elaborated to support any value by changing the 
+ * hardcoded new value passed to __atomic_exchange* from 1 to @param count
+ * i.e oldvalue_var = atomic_exchange_explicit(&var, count).
+ * However, in order to be compatible with the __sync functions family, we can use only 0 and 1.
+ * The only exchange alternative suggested by __sync is __sync_lock_test_and_set, 
+ * But as described by the gnu manual for __sync_lock_test_and_set():
+ * https://gcc.gnu.org/onlinedocs/gcc/_005f_005fsync-Builtins.html
+ * "A target may support reduced functionality here by which the only valid value to store is the immediate constant 1. The exact value
+ * actually stored in *ptr is implementation defined."
+ * Hence, we can't rely on it for a any value other than 1.
+ * We eventually chose to implement this method with __sync_val_compare_and_swap since it satisfies functionality needed for atomicFlagGetSet
+ * (if the flag was 0 -> set to 1, if it's already 1 -> do nothing, but the final result is that the flag is set), 
+ * and also it has a full barrier (__sync_lock_test_and_set has acquire barrier).
+ * 
+ * NOTE2: Unlike other atomic type, which aren't guaranteed to be lock free, c11 atmoic_flag does.
+ * To check wether a type is lock free, atomic_is_lock_free() can be used. 
+ * It can be considered to limit the flag type to atomic_flag to improve performance.
+ * 
  * Never use return value from the macros, instead use the AtomicGetIncr()
  * if you need to get the current value and increment it atomically, like
  * in the following example:
@@ -114,13 +130,8 @@
 } while(0)
 #define atomicSetWithSync(var,value) \
     atomic_store_explicit(&var,value,memory_order_seq_cst)
-/* Atomic flag definitions */
-#define redisAtomicFlag atomic_flag
-#define REDIS_ATOMIC_FLAG_INIT ATOMIC_FLAG_INIT
-#define atomicFlagTestSet(var, testres_var) \
-    testres_var = atomic_flag_test_and_set_explicit(&var,memory_order_relaxed)
-#define atomicFlagClear(var) \
-    atomic_flag_clear_explicit(&var,memory_order_relaxed)
+#define atomicFlagGetSet(var,oldvalue_var) \
+    oldvalue_var = atomic_exchange_explicit(&var,1,memory_order_relaxed)
 #define REDIS_ATOMIC_API "c11-builtin"
 
 #elif !defined(__ATOMIC_VAR_FORCE_SYNC_MACROS) && \
@@ -144,19 +155,12 @@
 } while(0)
 #define atomicSetWithSync(var,value) \
     __atomic_store_n(&var,value,__ATOMIC_SEQ_CST)
-/* Atomic flag definitions */
-#define redisAtomicFlag unsigned char
-#define REDIS_ATOMIC_FLAG_INIT 0
-#define atomicFlagTestSet(var, testres_var) \
-    testres_var = __atomic_test_and_set(&var,__ATOMIC_RELAXED)
-#define atomicFlagClear(var) \
-    __atomic_clear(&var,__ATOMIC_RELAXED)
+#define atomicFlagGetSet(var,oldvalue_var) \
+    oldvalue_var = __atomic_exchange_n(&var,1,__ATOMIC_RELAXED)
 #define REDIS_ATOMIC_API "atomic-builtin"
 
 #elif defined(HAVE_ATOMIC)
 /* Implementation using __sync macros. */
-
-
 
 #define atomicIncr(var,count) __sync_add_and_fetch(&var,(count))
 #define atomicIncrGet(var, newvalue_var, count) \
@@ -180,15 +184,8 @@
     ANNOTATE_HAPPENS_BEFORE(&var);  \
     while(!__sync_bool_compare_and_swap(&var,var,value,__sync_synchronize)); \
 } while(0)
-/* Atomic flag definitions */
-/* According to Intel Itanium Processor-specific Application Binary Interface, section 7.4, 
-__sync operations on booleans expect int operand. */
-#define redisAtomicFlag int
-#define REDIS_ATOMIC_FLAG_INIT 0
-#define atomicFlagTestSet(var, testres_var) \
-    testres_var = __sync_bool_compare_and_swap(&var,0,1)
-#define atomicFlagClear(var) \
-    __sync_bool_compare_and_swap(&var,1,0)
+#define atomicFlagGetSet(var,oldvalue_var) \
+    oldvalue_var = __sync_val_compare_and_swap(&var,0,1)
 #define REDIS_ATOMIC_API "sync-builtin"
 
 #else


### PR DESCRIPTION
atomic operations on flags can be performed any integer type. atomicFlagGetSet perfoms exchange when it is supported and compare_and_swap when it doesnt. atomicFlagClear is removed, atmoicSet is good enough to set the value to 0.

also, dropped stdbool. using a simple int.